### PR TITLE
Add binary operator rule to config file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
     args: [--standard=PSR2 -p --config-set ignore_warnings_on_exit 1]
   - id: php-cs-fixer
     files: \.(php)$
-    args: [--rules=@PSR2 -vv --allow-risky=no]
+    args: ["--rules=@PSR2,binary_operator_spaces -vv --allow-risky=no"]


### PR DESCRIPTION
Modificato il file di configurazione per includere una rule mancante, la `binary_operator_spaces` che formatta le variabili e il simbolo di uguale durante il processo di linting, cosi da uniformare per tutti.